### PR TITLE
US-2: Device schema versions with parameter definitions

### DIFF
--- a/app/Domain/DeviceTypes/Models/DeviceType.php
+++ b/app/Domain/DeviceTypes/Models/DeviceType.php
@@ -7,11 +7,13 @@ namespace App\Domain\DeviceTypes\Models;
 use App\Domain\DeviceTypes\Casts\ProtocolConfigCast;
 use App\Domain\DeviceTypes\Enums\ProtocolType;
 use App\Domain\DeviceTypes\ValueObjects\Protocol\ProtocolConfigInterface;
+use App\Domain\IoT\Models\DeviceSchema;
 use App\Domain\Shared\Models\Organization;
 use Database\Factories\DeviceTypeFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 /**
  * @property ProtocolConfigInterface|null $protocol_config
@@ -48,6 +50,14 @@ class DeviceType extends Model
     public function organization(): BelongsTo
     {
         return $this->belongsTo(Organization::class);
+    }
+
+    /**
+     * @return HasMany<DeviceSchema, $this>
+     */
+    public function schemas(): HasMany
+    {
+        return $this->hasMany(DeviceSchema::class, 'device_type_id');
     }
 
     /**

--- a/app/Domain/IoT/Enums/ParameterDataType.php
+++ b/app/Domain/IoT/Enums/ParameterDataType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Enums;
+
+enum ParameterDataType: string
+{
+    case Integer = 'integer';
+    case Decimal = 'decimal';
+    case Boolean = 'boolean';
+    case String = 'string';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Integer => 'Integer',
+            self::Decimal => 'Decimal',
+            self::Boolean => 'Boolean',
+            self::String => 'String',
+        };
+    }
+}

--- a/app/Domain/IoT/Models/DeviceSchema.php
+++ b/app/Domain/IoT/Models/DeviceSchema.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Models;
+
+use App\Domain\DeviceTypes\Models\DeviceType;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class DeviceSchema extends Model
+{
+    /** @use HasFactory<\Database\Factories\Domain\IoT\Models\DeviceSchemaFactory> */
+    use HasFactory;
+
+    use SoftDeletes;
+
+    protected $guarded = ['id'];
+
+    /**
+     * @return BelongsTo<DeviceType, $this>
+     */
+    public function deviceType(): BelongsTo
+    {
+        return $this->belongsTo(DeviceType::class);
+    }
+
+    /**
+     * @return HasMany<DeviceSchemaVersion, $this>
+     */
+    public function versions(): HasMany
+    {
+        return $this->hasMany(DeviceSchemaVersion::class);
+    }
+}

--- a/app/Domain/IoT/Models/DeviceSchemaVersion.php
+++ b/app/Domain/IoT/Models/DeviceSchemaVersion.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class DeviceSchemaVersion extends Model
+{
+    /** @use HasFactory<\Database\Factories\Domain\IoT\Models\DeviceSchemaVersionFactory> */
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    /**
+     * @return BelongsTo<DeviceSchema, $this>
+     */
+    public function schema(): BelongsTo
+    {
+        return $this->belongsTo(DeviceSchema::class, 'device_schema_id');
+    }
+
+    /**
+     * @return HasMany<ParameterDefinition, $this>
+     */
+    public function parameters(): HasMany
+    {
+        return $this->hasMany(ParameterDefinition::class, 'device_schema_version_id');
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 'active';
+    }
+}

--- a/app/Domain/IoT/Models/ParameterDefinition.php
+++ b/app/Domain/IoT/Models/ParameterDefinition.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Models;
+
+use App\Domain\IoT\Enums\ParameterDataType;
+use App\Domain\IoT\Support\JsonLogicEvaluator;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ParameterDefinition extends Model
+{
+    /** @use HasFactory<\Database\Factories\Domain\IoT\Models\ParameterDefinitionFactory> */
+    use HasFactory;
+
+    protected $guarded = ['id'];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'type' => ParameterDataType::class,
+            'required' => 'bool',
+            'is_critical' => 'bool',
+            'is_active' => 'bool',
+            'validation_rules' => 'array',
+            'mutation_expression' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<DeviceSchemaVersion, $this>
+     */
+    public function schemaVersion(): BelongsTo
+    {
+        return $this->belongsTo(DeviceSchemaVersion::class, 'device_schema_version_id');
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function extractValue(array $payload): mixed
+    {
+        $path = $this->normalizeJsonPath($this->json_path);
+
+        if ($path === null) {
+            return null;
+        }
+
+        return data_get($payload, $path);
+    }
+
+    public function mutateValue(mixed $value): mixed
+    {
+        $mutationExpression = $this->getAttribute('mutation_expression');
+
+        if (! is_array($mutationExpression) || $mutationExpression === []) {
+            return $value;
+        }
+
+        $evaluator = new JsonLogicEvaluator;
+
+        return $evaluator->evaluate($mutationExpression, [
+            'val' => $value,
+        ]);
+    }
+
+    /**
+     * @return array{is_valid: bool, error_code: string|null, is_critical: bool}
+     */
+    public function validateValue(mixed $value): array
+    {
+        if ($this->required && ($value === null || $value === '')) {
+            return $this->invalidResult();
+        }
+
+        if ($value === null || $value === '') {
+            return $this->validResult();
+        }
+
+        if (! $this->matchesDataType($value)) {
+            return $this->invalidResult();
+        }
+
+        $rules = $this->getAttribute('validation_rules');
+
+        if (! is_array($rules)) {
+            $rules = [];
+        }
+
+        if (array_key_exists('min', $rules) && is_numeric($value)) {
+            if ($value < $rules['min']) {
+                return $this->invalidResult();
+            }
+        }
+
+        if (array_key_exists('max', $rules) && is_numeric($value)) {
+            if ($value > $rules['max']) {
+                return $this->invalidResult();
+            }
+        }
+
+        if (array_key_exists('regex', $rules) && is_string($value)) {
+            if (! is_string($rules['regex']) || @preg_match($rules['regex'], '') === false) {
+                return $this->invalidResult();
+            }
+
+            if (! preg_match($rules['regex'], $value)) {
+                return $this->invalidResult();
+            }
+        }
+
+        if (array_key_exists('enum', $rules) && is_array($rules['enum'])) {
+            if (! in_array($value, $rules['enum'], true)) {
+                return $this->invalidResult();
+            }
+        }
+
+        return $this->validResult();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{value: mixed, mutated: mixed, validation: array{is_valid: bool, error_code: string|null, is_critical: bool}}
+     */
+    public function evaluatePayload(array $payload): array
+    {
+        $value = $this->extractValue($payload);
+        $mutated = $this->mutateValue($value);
+        $validation = $this->validateValue($mutated);
+
+        return [
+            'value' => $value,
+            'mutated' => $mutated,
+            'validation' => $validation,
+        ];
+    }
+
+    private function normalizeJsonPath(string $path): ?string
+    {
+        $normalized = trim($path);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        if ($normalized === '$') {
+            return null;
+        }
+
+        if (str_starts_with($normalized, '$.')) {
+            $normalized = substr($normalized, 2);
+        }
+
+        return $normalized;
+    }
+
+    private function matchesDataType(mixed $value): bool
+    {
+        $type = $this->getAttribute('type');
+
+        if (! $type instanceof ParameterDataType) {
+            if (! is_string($type) && ! is_int($type)) {
+                return false;
+            }
+
+            $type = ParameterDataType::tryFrom((string) $type);
+
+            if ($type === null) {
+                return false;
+            }
+        }
+
+        return match ($type) {
+            ParameterDataType::Integer => is_int($value) || (is_string($value) && preg_match('/^-?\d+$/', $value) === 1),
+            ParameterDataType::Decimal => is_numeric($value),
+            ParameterDataType::Boolean => is_bool($value) || in_array($value, ['true', 'false', 0, 1, '0', '1'], true),
+            ParameterDataType::String => is_string($value),
+        };
+    }
+
+    /**
+     * @return array{is_valid: bool, error_code: string|null, is_critical: bool}
+     */
+    private function invalidResult(): array
+    {
+        return [
+            'is_valid' => false,
+            'error_code' => $this->validation_error_code,
+            'is_critical' => $this->is_critical,
+        ];
+    }
+
+    /**
+     * @return array{is_valid: bool, error_code: string|null, is_critical: bool}
+     */
+    private function validResult(): array
+    {
+        return [
+            'is_valid' => true,
+            'error_code' => null,
+            'is_critical' => false,
+        ];
+    }
+}

--- a/app/Domain/IoT/Permissions/DeviceSchemaPermission.php
+++ b/app/Domain/IoT/Permissions/DeviceSchemaPermission.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Permissions;
+
+use Althinect\EnumPermission\Concerns\HasPermissionGroup;
+
+enum DeviceSchemaPermission: string
+{
+    use HasPermissionGroup;
+
+    case VIEW_ANY = 'DeviceSchema.view-any';
+    case VIEW = 'DeviceSchema.view';
+    case CREATE = 'DeviceSchema.create';
+    case UPDATE = 'DeviceSchema.update';
+    case DELETE = 'DeviceSchema.delete';
+    case RESTORE = 'DeviceSchema.restore';
+    case FORCE_DELETE = 'DeviceSchema.force-delete';
+}

--- a/app/Domain/IoT/Permissions/DeviceSchemaVersionPermission.php
+++ b/app/Domain/IoT/Permissions/DeviceSchemaVersionPermission.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Permissions;
+
+use Althinect\EnumPermission\Concerns\HasPermissionGroup;
+
+enum DeviceSchemaVersionPermission: string
+{
+    use HasPermissionGroup;
+
+    case VIEW_ANY = 'DeviceSchemaVersion.view-any';
+    case VIEW = 'DeviceSchemaVersion.view';
+    case CREATE = 'DeviceSchemaVersion.create';
+    case UPDATE = 'DeviceSchemaVersion.update';
+    case DELETE = 'DeviceSchemaVersion.delete';
+    case RESTORE = 'DeviceSchemaVersion.restore';
+    case FORCE_DELETE = 'DeviceSchemaVersion.force-delete';
+}

--- a/app/Domain/IoT/Permissions/ParameterDefinitionPermission.php
+++ b/app/Domain/IoT/Permissions/ParameterDefinitionPermission.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Permissions;
+
+use Althinect\EnumPermission\Concerns\HasPermissionGroup;
+
+enum ParameterDefinitionPermission: string
+{
+    use HasPermissionGroup;
+
+    case VIEW_ANY = 'ParameterDefinition.view-any';
+    case VIEW = 'ParameterDefinition.view';
+    case CREATE = 'ParameterDefinition.create';
+    case UPDATE = 'ParameterDefinition.update';
+    case DELETE = 'ParameterDefinition.delete';
+    case RESTORE = 'ParameterDefinition.restore';
+    case FORCE_DELETE = 'ParameterDefinition.force-delete';
+}

--- a/app/Domain/IoT/Support/JsonLogicEvaluator.php
+++ b/app/Domain/IoT/Support/JsonLogicEvaluator.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Support;
+
+class JsonLogicEvaluator
+{
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public function evaluate(mixed $expression, array $data = []): mixed
+    {
+        if (! is_array($expression)) {
+            return $expression;
+        }
+
+        if (! $this->isAssoc($expression)) {
+            return array_map(fn (mixed $item) => $this->evaluate($item, $data), $expression);
+        }
+
+        if (count($expression) !== 1) {
+            return $expression;
+        }
+
+        $operator = array_key_first($expression);
+        $values = $expression[$operator];
+
+        return $this->applyOperator((string) $operator, $values, $data);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function applyOperator(string $operator, mixed $values, array $data): mixed
+    {
+        return match ($operator) {
+            'var' => $this->resolveVar($values, $data),
+            '+', '-', '*', '/', 'min', 'max' => $this->applyNumericOperator($operator, $values, $data),
+            'if' => $this->applyIf($values, $data),
+            default => $values,
+        };
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function resolveVar(mixed $values, array $data): mixed
+    {
+        if (is_array($values)) {
+            $path = $values[0] ?? null;
+            $default = $values[1] ?? null;
+        } else {
+            $path = $values;
+            $default = null;
+        }
+
+        if (! is_string($path) || $path === '') {
+            return $default;
+        }
+
+        return data_get($data, $path, $default);
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function applyNumericOperator(string $operator, mixed $values, array $data): mixed
+    {
+        $items = is_array($values) ? $values : [$values];
+        $evaluated = array_map(fn (mixed $item) => $this->evaluate($item, $data), $items);
+        $numbers = array_map([$this, 'toNumber'], $evaluated);
+
+        return match ($operator) {
+            '+' => array_sum($numbers),
+            '-' => $this->subtract($numbers),
+            '*' => $this->multiply($numbers),
+            '/' => $this->divide($numbers),
+            'min' => $numbers === [] ? null : min($numbers),
+            'max' => $numbers === [] ? null : max($numbers),
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<int, float>  $numbers
+     */
+    private function subtract(array $numbers): float
+    {
+        $result = array_shift($numbers) ?? 0.0;
+
+        foreach ($numbers as $number) {
+            $result -= $number;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<int, float>  $numbers
+     */
+    private function multiply(array $numbers): float
+    {
+        $result = 1.0;
+
+        foreach ($numbers as $number) {
+            $result *= $number;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<int, float>  $numbers
+     */
+    private function divide(array $numbers): float
+    {
+        $result = array_shift($numbers) ?? 0.0;
+
+        foreach ($numbers as $number) {
+            if ($number == 0.0) {
+                return $result;
+            }
+
+            $result /= $number;
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function applyIf(mixed $values, array $data): mixed
+    {
+        $items = is_array($values) ? $values : [$values];
+        $condition = $items[0] ?? null;
+        $truthy = $items[1] ?? null;
+        $falsy = $items[2] ?? null;
+
+        return $this->evaluate($condition, $data) ? $this->evaluate($truthy, $data) : $this->evaluate($falsy, $data);
+    }
+
+    private function toNumber(mixed $value): float
+    {
+        if (is_bool($value)) {
+            return $value ? 1.0 : 0.0;
+        }
+
+        if (is_numeric($value)) {
+            return (float) $value;
+        }
+
+        return 0.0;
+    }
+
+    /**
+     * @param  array<mixed, mixed>  $value
+     */
+    private function isAssoc(array $value): bool
+    {
+        return array_keys($value) !== range(0, count($value) - 1);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/DeviceSchemaVersionResource.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/DeviceSchemaVersionResource.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions;
+
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages\CreateDeviceSchemaVersion;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages\EditDeviceSchemaVersion;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages\ListDeviceSchemaVersions;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages\ViewDeviceSchemaVersion;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\RelationManagers\ParameterDefinitionsRelationManager;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Schemas\DeviceSchemaVersionForm;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Schemas\DeviceSchemaVersionInfolist;
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Tables\DeviceSchemaVersionsTable;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class DeviceSchemaVersionResource extends Resource
+{
+    protected static ?string $model = DeviceSchemaVersion::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedClipboardDocumentList;
+
+    protected static ?int $navigationSort = 3;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('IoT Management');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Schema Versions');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return DeviceSchemaVersionForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return DeviceSchemaVersionInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return DeviceSchemaVersionsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            ParameterDefinitionsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDeviceSchemaVersions::route('/'),
+            'create' => CreateDeviceSchemaVersion::route('/create'),
+            'view' => ViewDeviceSchemaVersion::route('/{record}'),
+            'edit' => EditDeviceSchemaVersion::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/CreateDeviceSchemaVersion.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/CreateDeviceSchemaVersion.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\DeviceSchemaVersionResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDeviceSchemaVersion extends CreateRecord
+{
+    protected static string $resource = DeviceSchemaVersionResource::class;
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/EditDeviceSchemaVersion.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/EditDeviceSchemaVersion.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\DeviceSchemaVersionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDeviceSchemaVersion extends EditRecord
+{
+    protected static string $resource = DeviceSchemaVersionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/ListDeviceSchemaVersions.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/ListDeviceSchemaVersions.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\DeviceSchemaVersionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDeviceSchemaVersions extends ListRecords
+{
+    protected static string $resource = DeviceSchemaVersionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/ViewDeviceSchemaVersion.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Pages/ViewDeviceSchemaVersion.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\DeviceSchemaVersionResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDeviceSchemaVersion extends ViewRecord
+{
+    protected static string $resource = DeviceSchemaVersionResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/RelationManagers/ParameterDefinitionsRelationManager.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/RelationManagers/ParameterDefinitionsRelationManager.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\RelationManagers;
+
+use App\Domain\IoT\Enums\ParameterDataType;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\CodeEditor;
+use Filament\Forms\Components\CodeEditor\Enums\Language;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class ParameterDefinitionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'parameters';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('key')
+                    ->required()
+                    ->maxLength(100),
+
+                TextInput::make('label')
+                    ->required()
+                    ->maxLength(255),
+
+                TextInput::make('json_path')
+                    ->required()
+                    ->maxLength(255)
+                    ->helperText('Example: $.status.temp or temp'),
+
+                Select::make('type')
+                    ->options(ParameterDataType::class)
+                    ->required(),
+
+                TextInput::make('unit')
+                    ->maxLength(50)
+                    ->placeholder('Celsius'),
+
+                Toggle::make('required')
+                    ->label('Required'),
+
+                Toggle::make('is_critical')
+                    ->label('Critical'),
+
+                CodeEditor::make('validation_rules')
+                    ->language(Language::Json)
+                    ->columnSpanFull()
+                    ->helperText('JSON rules, e.g. {"min": -40, "max": 85}')
+                    ->formatStateUsing(function (mixed $state): ?string {
+                        if (is_array($state)) {
+                            $encoded = json_encode($state, JSON_PRETTY_PRINT);
+
+                            return $encoded === false ? null : $encoded;
+                        }
+
+                        return is_string($state) ? $state : null;
+                    })
+                    ->dehydrateStateUsing(fn (?string $state): mixed => $state ? json_decode($state, true) : null),
+
+                TextInput::make('validation_error_code')
+                    ->maxLength(100)
+                    ->placeholder('TEMP_RANGE'),
+
+                CodeEditor::make('mutation_expression')
+                    ->language(Language::Json)
+                    ->columnSpanFull()
+                    ->helperText('JsonLogic expression')
+                    ->formatStateUsing(function (mixed $state): ?string {
+                        if (is_array($state)) {
+                            $encoded = json_encode($state, JSON_PRETTY_PRINT);
+
+                            return $encoded === false ? null : $encoded;
+                        }
+
+                        return is_string($state) ? $state : null;
+                    })
+                    ->dehydrateStateUsing(fn (?string $state): mixed => $state ? json_decode($state, true) : null),
+
+                TextInput::make('sequence')
+                    ->integer()
+                    ->minValue(0)
+                    ->default(0),
+
+                Toggle::make('is_active')
+                    ->label('Active')
+                    ->default(true),
+            ])
+            ->columns(2);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('key')
+            ->columns([
+                TextColumn::make('key')
+                    ->searchable(),
+
+                TextColumn::make('label')
+                    ->searchable(),
+
+                TextColumn::make('type')
+                    ->formatStateUsing(fn (ParameterDataType|string $state): string => $state instanceof ParameterDataType ? $state->label() : (string) $state)
+                    ->badge(),
+
+                IconColumn::make('required')
+                    ->boolean(),
+
+                IconColumn::make('is_critical')
+                    ->label('Critical')
+                    ->boolean(),
+
+                IconColumn::make('is_active')
+                    ->label('Active')
+                    ->boolean(),
+
+                TextColumn::make('sequence')
+                    ->sortable(),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Schemas/DeviceSchemaVersionForm.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Schemas/DeviceSchemaVersionForm.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Schemas;
+
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class DeviceSchemaVersionForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Version Details')
+                    ->schema([
+                        Select::make('device_schema_id')
+                            ->label('Device Schema')
+                            ->relationship('schema', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->required(),
+
+                        TextInput::make('version')
+                            ->required()
+                            ->integer()
+                            ->minValue(1),
+
+                        Select::make('status')
+                            ->options([
+                                'draft' => 'Draft',
+                                'active' => 'Active',
+                                'archived' => 'Archived',
+                            ])
+                            ->required()
+                            ->default('draft'),
+
+                        Textarea::make('notes')
+                            ->rows(3)
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Schemas/DeviceSchemaVersionInfolist.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Schemas/DeviceSchemaVersionInfolist.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Schemas;
+
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+
+class DeviceSchemaVersionInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Version')
+                    ->schema([
+                        TextEntry::make('schema.name')
+                            ->label('Device Schema')
+                            ->icon(Heroicon::OutlinedRectangleStack),
+                        TextEntry::make('version')
+                            ->label('Version'),
+                        TextEntry::make('status')
+                            ->badge(),
+                        TextEntry::make('notes')
+                            ->placeholder('—')
+                            ->columnSpanFull(),
+                    ])
+                    ->columns(2),
+
+                Section::make('Timestamps')
+                    ->schema([
+                        TextEntry::make('created_at')
+                            ->dateTime()
+                            ->icon(Heroicon::OutlinedClock),
+                        TextEntry::make('updated_at')
+                            ->dateTime()
+                            ->icon(Heroicon::OutlinedClock),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Tables/DeviceSchemaVersionsTable.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemaVersions/Tables/DeviceSchemaVersionsTable.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemaVersions\Tables;
+
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DeviceSchemaVersionsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('schema.name')
+                    ->label('Device Schema')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('version')
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'draft' => 'warning',
+                        'active' => 'success',
+                        'archived' => 'gray',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+
+                TextColumn::make('parameters_count')
+                    ->label('Parameters')
+                    ->counts('parameters')
+                    ->sortable(),
+
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/DeviceSchemaResource.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/DeviceSchemaResource.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas;
+
+use App\Domain\IoT\Models\DeviceSchema;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages\CreateDeviceSchema;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages\EditDeviceSchema;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages\ListDeviceSchemas;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages\ViewDeviceSchema;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\RelationManagers\DeviceSchemaVersionsRelationManager;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\Schemas\DeviceSchemaForm;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\Schemas\DeviceSchemaInfolist;
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\Tables\DeviceSchemasTable;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class DeviceSchemaResource extends Resource
+{
+    protected static ?string $model = DeviceSchema::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+
+    protected static ?int $navigationSort = 2;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('IoT Management');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Device Schemas');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return DeviceSchemaForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return DeviceSchemaInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return DeviceSchemasTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            DeviceSchemaVersionsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDeviceSchemas::route('/'),
+            'create' => CreateDeviceSchema::route('/create'),
+            'view' => ViewDeviceSchema::route('/{record}'),
+            'edit' => EditDeviceSchema::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/CreateDeviceSchema.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/CreateDeviceSchema.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\DeviceSchemaResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDeviceSchema extends CreateRecord
+{
+    protected static string $resource = DeviceSchemaResource::class;
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/EditDeviceSchema.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/EditDeviceSchema.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\DeviceSchemaResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDeviceSchema extends EditRecord
+{
+    protected static string $resource = DeviceSchemaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/ListDeviceSchemas.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/ListDeviceSchemas.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\DeviceSchemaResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDeviceSchemas extends ListRecords
+{
+    protected static string $resource = DeviceSchemaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/ViewDeviceSchema.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/Pages/ViewDeviceSchema.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceSchemas\DeviceSchemaResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDeviceSchema extends ViewRecord
+{
+    protected static string $resource = DeviceSchemaResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/RelationManagers/DeviceSchemaVersionsRelationManager.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/RelationManagers/DeviceSchemaVersionsRelationManager.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\RelationManagers;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\CreateAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DeviceSchemaVersionsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'versions';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('version')
+                    ->required()
+                    ->integer()
+                    ->minValue(1),
+
+                Select::make('status')
+                    ->options([
+                        'draft' => 'Draft',
+                        'active' => 'Active',
+                        'archived' => 'Archived',
+                    ])
+                    ->required()
+                    ->default('draft'),
+
+                Textarea::make('notes')
+                    ->rows(3)
+                    ->columnSpanFull(),
+            ])
+            ->columns(2);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('version')
+            ->columns([
+                TextColumn::make('version')
+                    ->sortable(),
+
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        'draft' => 'warning',
+                        'active' => 'success',
+                        'archived' => 'gray',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+
+                TextColumn::make('parameters_count')
+                    ->label('Parameters')
+                    ->counts('parameters'),
+            ])
+            ->headerActions([
+                CreateAction::make(),
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/Schemas/DeviceSchemaForm.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/Schemas/DeviceSchemaForm.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\Schemas;
+
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+
+class DeviceSchemaForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Schema Details')
+                    ->schema([
+                        Select::make('device_type_id')
+                            ->label('Device Type')
+                            ->relationship('deviceType', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->required(),
+
+                        TextInput::make('name')
+                            ->required()
+                            ->maxLength(255),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/Schemas/DeviceSchemaInfolist.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/Schemas/DeviceSchemaInfolist.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\Schemas;
+
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+
+class DeviceSchemaInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Schema')
+                    ->schema([
+                        TextEntry::make('name')
+                            ->weight('medium'),
+                        TextEntry::make('deviceType.name')
+                            ->label('Device Type')
+                            ->icon(Heroicon::OutlinedCube),
+                    ])
+                    ->columns(2),
+
+                Section::make('Timestamps')
+                    ->schema([
+                        TextEntry::make('created_at')
+                            ->dateTime()
+                            ->icon(Heroicon::OutlinedClock),
+                        TextEntry::make('updated_at')
+                            ->dateTime()
+                            ->icon(Heroicon::OutlinedClock),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceSchemas/Tables/DeviceSchemasTable.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceSchemas/Tables/DeviceSchemasTable.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceSchemas\Tables;
+
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class DeviceSchemasTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('deviceType.name')
+                    ->label('Device Type')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('versions_count')
+                    ->label('Versions')
+                    ->counts('versions')
+                    ->sortable(),
+
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/app/Policies/DeviceSchemaPolicy.php
+++ b/app/Policies/DeviceSchemaPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Domain\IoT\Models\DeviceSchema;
+use App\Domain\IoT\Permissions\DeviceSchemaPermission;
+use App\Domain\Shared\Models\User;
+
+class DeviceSchemaPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaPermission::VIEW_ANY);
+    }
+
+    public function view(User $user, DeviceSchema $deviceSchema): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaPermission::VIEW);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaPermission::CREATE);
+    }
+
+    public function update(User $user, DeviceSchema $deviceSchema): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaPermission::UPDATE);
+    }
+
+    public function delete(User $user, DeviceSchema $deviceSchema): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaPermission::DELETE);
+    }
+
+    public function restore(User $user, DeviceSchema $deviceSchema): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaPermission::RESTORE);
+    }
+
+    public function forceDelete(User $user, DeviceSchema $deviceSchema): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaPermission::FORCE_DELETE);
+    }
+}

--- a/app/Policies/DeviceSchemaVersionPolicy.php
+++ b/app/Policies/DeviceSchemaVersionPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\IoT\Permissions\DeviceSchemaVersionPermission;
+use App\Domain\Shared\Models\User;
+
+class DeviceSchemaVersionPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaVersionPermission::VIEW_ANY);
+    }
+
+    public function view(User $user, DeviceSchemaVersion $deviceSchemaVersion): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaVersionPermission::VIEW);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaVersionPermission::CREATE);
+    }
+
+    public function update(User $user, DeviceSchemaVersion $deviceSchemaVersion): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaVersionPermission::UPDATE);
+    }
+
+    public function delete(User $user, DeviceSchemaVersion $deviceSchemaVersion): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaVersionPermission::DELETE);
+    }
+
+    public function restore(User $user, DeviceSchemaVersion $deviceSchemaVersion): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaVersionPermission::RESTORE);
+    }
+
+    public function forceDelete(User $user, DeviceSchemaVersion $deviceSchemaVersion): bool
+    {
+        return $user->hasPermissionTo(DeviceSchemaVersionPermission::FORCE_DELETE);
+    }
+}

--- a/app/Policies/ParameterDefinitionPolicy.php
+++ b/app/Policies/ParameterDefinitionPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Domain\IoT\Models\ParameterDefinition;
+use App\Domain\IoT\Permissions\ParameterDefinitionPermission;
+use App\Domain\Shared\Models\User;
+
+class ParameterDefinitionPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo(ParameterDefinitionPermission::VIEW_ANY);
+    }
+
+    public function view(User $user, ParameterDefinition $parameterDefinition): bool
+    {
+        return $user->hasPermissionTo(ParameterDefinitionPermission::VIEW);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo(ParameterDefinitionPermission::CREATE);
+    }
+
+    public function update(User $user, ParameterDefinition $parameterDefinition): bool
+    {
+        return $user->hasPermissionTo(ParameterDefinitionPermission::UPDATE);
+    }
+
+    public function delete(User $user, ParameterDefinition $parameterDefinition): bool
+    {
+        return $user->hasPermissionTo(ParameterDefinitionPermission::DELETE);
+    }
+
+    public function restore(User $user, ParameterDefinition $parameterDefinition): bool
+    {
+        return $user->hasPermissionTo(ParameterDefinitionPermission::RESTORE);
+    }
+
+    public function forceDelete(User $user, ParameterDefinition $parameterDefinition): bool
+    {
+        return $user->hasPermissionTo(ParameterDefinitionPermission::FORCE_DELETE);
+    }
+}

--- a/database/factories/Domain/IoT/Models/DeviceSchemaFactory.php
+++ b/database/factories/Domain/IoT/Models/DeviceSchemaFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Domain\IoT\Models;
+
+use App\Domain\DeviceTypes\Models\DeviceType;
+use App\Domain\IoT\Models\DeviceSchema;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Domain\IoT\Models\DeviceSchema>
+ */
+class DeviceSchemaFactory extends Factory
+{
+    protected $model = DeviceSchema::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'device_type_id' => DeviceType::factory(),
+            'name' => $this->faker->words(3, true),
+        ];
+    }
+
+    public function forDeviceType(DeviceType $deviceType): static
+    {
+        return $this->state(fn () => [
+            'device_type_id' => $deviceType->id,
+        ]);
+    }
+}

--- a/database/factories/Domain/IoT/Models/DeviceSchemaVersionFactory.php
+++ b/database/factories/Domain/IoT/Models/DeviceSchemaVersionFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Domain\IoT\Models;
+
+use App\Domain\IoT\Models\DeviceSchema;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Domain\IoT\Models\DeviceSchemaVersion>
+ */
+class DeviceSchemaVersionFactory extends Factory
+{
+    protected $model = DeviceSchemaVersion::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'device_schema_id' => DeviceSchema::factory(),
+            'version' => 1,
+            'status' => 'draft',
+            'notes' => $this->faker->optional()->sentence,
+        ];
+    }
+
+    public function active(): static
+    {
+        return $this->state(fn () => [
+            'status' => 'active',
+        ]);
+    }
+}

--- a/database/factories/Domain/IoT/Models/ParameterDefinitionFactory.php
+++ b/database/factories/Domain/IoT/Models/ParameterDefinitionFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Domain\IoT\Models;
+
+use App\Domain\IoT\Enums\ParameterDataType;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\IoT\Models\ParameterDefinition;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Domain\IoT\Models\ParameterDefinition>
+ */
+class ParameterDefinitionFactory extends Factory
+{
+    protected $model = ParameterDefinition::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $dataType = $this->faker->randomElement(ParameterDataType::cases());
+
+        return [
+            'device_schema_version_id' => DeviceSchemaVersion::factory(),
+            'key' => $this->faker->unique()->slug(2),
+            'label' => $this->faker->words(2, true),
+            'json_path' => $this->faker->randomElement(['temp', 'status.temp', '$.status.temp']),
+            'type' => $dataType,
+            'unit' => $dataType === ParameterDataType::Decimal ? $this->faker->randomElement(['Celsius', 'Percent', 'Volts']) : null,
+            'required' => $this->faker->boolean(60),
+            'is_critical' => $this->faker->boolean(20),
+            'validation_rules' => [
+                'min' => -40,
+                'max' => 85,
+            ],
+            'validation_error_code' => $this->faker->optional()->lexify('VAL_????'),
+            'mutation_expression' => [
+                '*' => [
+                    ['var' => 'val'],
+                    1.0,
+                ],
+            ],
+            'sequence' => $this->faker->numberBetween(1, 10),
+            'is_active' => $this->faker->boolean(90),
+        ];
+    }
+}

--- a/database/migrations/2026_02_06_080912_create_device_schemas_table.php
+++ b/database/migrations/2026_02_06_080912_create_device_schemas_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('device_schemas', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('device_type_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 255);
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('device_schemas');
+    }
+};

--- a/database/migrations/2026_02_06_080923_create_device_schema_versions_table.php
+++ b/database/migrations/2026_02_06_080923_create_device_schema_versions_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('device_schema_versions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('device_schema_id')->constrained()->cascadeOnDelete();
+            $table->unsignedInteger('version');
+            $table->string('status', 50)->default('draft');
+            $table->text('notes')->nullable();
+            $table->timestamps();
+
+            $table->unique(['device_schema_id', 'version'], 'device_schema_versions_schema_version_unique');
+            $table->index(['device_schema_id', 'status'], 'device_schema_versions_schema_status_index');
+        });
+
+        DB::statement("CREATE UNIQUE INDEX device_schema_versions_active_unique ON device_schema_versions (device_schema_id) WHERE status = 'active'");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS device_schema_versions_active_unique');
+        Schema::dropIfExists('device_schema_versions');
+    }
+};

--- a/database/migrations/2026_02_06_080925_create_parameter_definitions_table.php
+++ b/database/migrations/2026_02_06_080925_create_parameter_definitions_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('parameter_definitions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('device_schema_version_id')->constrained()->cascadeOnDelete();
+            $table->string('key', 100);
+            $table->string('label', 255);
+            $table->string('json_path', 255);
+            $table->string('type', 50);
+            $table->string('unit', 50)->nullable();
+            $table->boolean('required')->default(false);
+            $table->boolean('is_critical')->default(false);
+            $table->jsonb('validation_rules')->nullable();
+            $table->string('validation_error_code', 100)->nullable();
+            $table->jsonb('mutation_expression')->nullable();
+            $table->unsignedInteger('sequence')->default(0);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['device_schema_version_id', 'key'], 'parameter_definitions_version_key_unique');
+            $table->index(['device_schema_version_id', 'is_active'], 'parameter_definitions_version_active_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('parameter_definitions');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -36,6 +36,7 @@ class DatabaseSeeder extends Seeder
 
         $this->call([
             OrganizationSeeder::class,
+            DeviceSchemaSeeder::class,
         ]);
     }
 }

--- a/database/seeders/DeviceSchemaSeeder.php
+++ b/database/seeders/DeviceSchemaSeeder.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Domain\DeviceTypes\Enums\ProtocolType;
+use App\Domain\DeviceTypes\Models\DeviceType;
+use App\Domain\DeviceTypes\ValueObjects\Protocol\MqttProtocolConfig;
+use App\Domain\IoT\Enums\ParameterDataType;
+use App\Domain\IoT\Models\DeviceSchema;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\IoT\Models\ParameterDefinition;
+use Illuminate\Database\Seeder;
+
+class DeviceSchemaSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $thermalDeviceType = DeviceType::firstOrCreate(
+            ['key' => 'thermal_sensor'],
+            [
+                'organization_id' => null,
+                'name' => 'Thermal Sensor',
+                'default_protocol' => ProtocolType::Mqtt,
+                'protocol_config' => (new MqttProtocolConfig(
+                    brokerHost: 'mqtt.iot-platform.local',
+                    brokerPort: 1883,
+                    username: 'thermal_sensor',
+                    password: 'thermal_password',
+                    useTls: false,
+                    telemetryTopicTemplate: 'thermal/:device_uuid/telemetry',
+                    controlTopicTemplate: 'thermal/:device_uuid/control',
+                    qos: 1,
+                    retain: false,
+                ))->toArray(),
+            ]
+        );
+
+        $networkDeviceType = DeviceType::firstOrCreate(
+            ['key' => 'network_gateway'],
+            [
+                'organization_id' => null,
+                'name' => 'Network Gateway',
+                'default_protocol' => ProtocolType::Mqtt,
+                'protocol_config' => (new MqttProtocolConfig(
+                    brokerHost: 'mqtt.iot-platform.local',
+                    brokerPort: 1883,
+                    username: 'network_gateway',
+                    password: 'network_password',
+                    useTls: false,
+                    telemetryTopicTemplate: 'network/:device_uuid/telemetry',
+                    controlTopicTemplate: 'network/:device_uuid/control',
+                    qos: 1,
+                    retain: false,
+                ))->toArray(),
+            ]
+        );
+
+        $thermalSchema = DeviceSchema::firstOrCreate([
+            'device_type_id' => $thermalDeviceType->id,
+            'name' => 'Thermal Sensor Contract',
+        ]);
+
+        $thermalVersion = DeviceSchemaVersion::firstOrCreate([
+            'device_schema_id' => $thermalSchema->id,
+            'version' => 1,
+        ], [
+            'status' => 'active',
+            'notes' => 'Initial thermal sensor contract',
+        ]);
+
+        ParameterDefinition::firstOrCreate([
+            'device_schema_version_id' => $thermalVersion->id,
+            'key' => 'temp_c',
+        ], [
+            'label' => 'Temperature (°C)',
+            'json_path' => '$.status.temp',
+            'type' => ParameterDataType::Decimal,
+            'unit' => 'Celsius',
+            'required' => true,
+            'is_critical' => true,
+            'validation_rules' => ['min' => -40, 'max' => 85],
+            'validation_error_code' => 'TEMP_RANGE',
+            'mutation_expression' => [
+                '+' => [
+                    ['*' => [
+                        ['var' => 'val'],
+                        1.8,
+                    ]],
+                    32,
+                ],
+            ],
+            'sequence' => 1,
+            'is_active' => true,
+        ]);
+
+        ParameterDefinition::firstOrCreate([
+            'device_schema_version_id' => $thermalVersion->id,
+            'key' => 'humidity',
+        ], [
+            'label' => 'Humidity',
+            'json_path' => 'status.humidity',
+            'type' => ParameterDataType::Decimal,
+            'unit' => 'Percent',
+            'required' => true,
+            'is_critical' => false,
+            'validation_rules' => ['min' => 0, 'max' => 100],
+            'validation_error_code' => 'HUMIDITY_RANGE',
+            'sequence' => 2,
+            'is_active' => true,
+        ]);
+
+        $networkSchema = DeviceSchema::firstOrCreate([
+            'device_type_id' => $networkDeviceType->id,
+            'name' => 'Network Gateway Contract',
+        ]);
+
+        $networkVersion = DeviceSchemaVersion::firstOrCreate([
+            'device_schema_id' => $networkSchema->id,
+            'version' => 1,
+        ], [
+            'status' => 'active',
+            'notes' => 'Initial network telemetry contract',
+        ]);
+
+        ParameterDefinition::firstOrCreate([
+            'device_schema_version_id' => $networkVersion->id,
+            'key' => 'signal_strength',
+        ], [
+            'label' => 'Signal Strength',
+            'json_path' => 'radio.signal',
+            'type' => ParameterDataType::Integer,
+            'unit' => 'dBm',
+            'required' => true,
+            'is_critical' => false,
+            'validation_rules' => ['min' => -120, 'max' => 0],
+            'validation_error_code' => 'SIGNAL_RANGE',
+            'sequence' => 1,
+            'is_active' => true,
+        ]);
+
+        ParameterDefinition::firstOrCreate([
+            'device_schema_version_id' => $networkVersion->id,
+            'key' => 'uptime_seconds',
+        ], [
+            'label' => 'Uptime (seconds)',
+            'json_path' => '$.system.uptime',
+            'type' => ParameterDataType::Integer,
+            'unit' => 'Seconds',
+            'required' => false,
+            'is_critical' => false,
+            'validation_rules' => ['min' => 0],
+            'validation_error_code' => 'UPTIME_RANGE',
+            'sequence' => 2,
+            'is_active' => true,
+        ]);
+    }
+}

--- a/tests/Feature/Policies/DeviceSchemaPolicyTest.php
+++ b/tests/Feature/Policies/DeviceSchemaPolicyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\IoT\Models\DeviceSchema;
+use App\Domain\IoT\Permissions\DeviceSchemaPermission;
+use App\Domain\Shared\Models\Organization;
+use App\Domain\Shared\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $organization = Organization::factory()->create();
+    setPermissionsTeamId($organization->id);
+
+    foreach (DeviceSchemaPermission::cases() as $permission) {
+        Permission::findOrCreate($permission->value, 'web');
+    }
+});
+
+it('allows user with viewAny permission to view device schemas index', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Viewer', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaPermission::VIEW_ANY->value);
+    $user->assignRole($role);
+
+    expect($user->can('viewAny', DeviceSchema::class))->toBeTrue();
+});
+
+it('denies user without viewAny permission to view device schemas index', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->can('viewAny', DeviceSchema::class))->toBeFalse();
+});
+
+it('allows user with view permission to view a device schema', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Viewer', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaPermission::VIEW->value);
+    $user->assignRole($role);
+
+    $schema = DeviceSchema::factory()->create();
+
+    expect($user->can('view', $schema))->toBeTrue();
+});
+
+it('denies user without view permission to view a device schema', function (): void {
+    $user = User::factory()->create();
+    $schema = DeviceSchema::factory()->create();
+
+    expect($user->can('view', $schema))->toBeFalse();
+});
+
+it('allows user with create permission to create device schemas', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Creator', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaPermission::CREATE->value);
+    $user->assignRole($role);
+
+    expect($user->can('create', DeviceSchema::class))->toBeTrue();
+});
+
+it('denies user without create permission to create device schemas', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->can('create', DeviceSchema::class))->toBeFalse();
+});
+
+it('allows user with update permission to update a device schema', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Editor', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaPermission::UPDATE->value);
+    $user->assignRole($role);
+
+    $schema = DeviceSchema::factory()->create();
+
+    expect($user->can('update', $schema))->toBeTrue();
+});
+
+it('denies user without update permission to update a device schema', function (): void {
+    $user = User::factory()->create();
+    $schema = DeviceSchema::factory()->create();
+
+    expect($user->can('update', $schema))->toBeFalse();
+});
+
+it('allows user with delete permission to delete a device schema', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaPermission::DELETE->value);
+    $user->assignRole($role);
+
+    $schema = DeviceSchema::factory()->create();
+
+    expect($user->can('delete', $schema))->toBeTrue();
+});
+
+it('denies user without delete permission to delete a device schema', function (): void {
+    $user = User::factory()->create();
+    $schema = DeviceSchema::factory()->create();
+
+    expect($user->can('delete', $schema))->toBeFalse();
+});
+
+it('super admin can perform all actions on device schemas', function (): void {
+    $superAdmin = User::factory()->create(['is_super_admin' => true]);
+    $schema = DeviceSchema::factory()->create();
+
+    expect($superAdmin->can('viewAny', DeviceSchema::class))->toBeTrue()
+        ->and($superAdmin->can('view', $schema))->toBeTrue()
+        ->and($superAdmin->can('create', DeviceSchema::class))->toBeTrue()
+        ->and($superAdmin->can('update', $schema))->toBeTrue()
+        ->and($superAdmin->can('delete', $schema))->toBeTrue();
+});

--- a/tests/Feature/Policies/DeviceSchemaVersionPolicyTest.php
+++ b/tests/Feature/Policies/DeviceSchemaVersionPolicyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\IoT\Permissions\DeviceSchemaVersionPermission;
+use App\Domain\Shared\Models\Organization;
+use App\Domain\Shared\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $organization = Organization::factory()->create();
+    setPermissionsTeamId($organization->id);
+
+    foreach (DeviceSchemaVersionPermission::cases() as $permission) {
+        Permission::findOrCreate($permission->value, 'web');
+    }
+});
+
+it('allows user with viewAny permission to view schema versions index', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Viewer', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaVersionPermission::VIEW_ANY->value);
+    $user->assignRole($role);
+
+    expect($user->can('viewAny', DeviceSchemaVersion::class))->toBeTrue();
+});
+
+it('denies user without viewAny permission to view schema versions index', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->can('viewAny', DeviceSchemaVersion::class))->toBeFalse();
+});
+
+it('allows user with view permission to view a schema version', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Viewer', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaVersionPermission::VIEW->value);
+    $user->assignRole($role);
+
+    $version = DeviceSchemaVersion::factory()->create();
+
+    expect($user->can('view', $version))->toBeTrue();
+});
+
+it('denies user without view permission to view a schema version', function (): void {
+    $user = User::factory()->create();
+    $version = DeviceSchemaVersion::factory()->create();
+
+    expect($user->can('view', $version))->toBeFalse();
+});
+
+it('allows user with create permission to create schema versions', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Creator', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaVersionPermission::CREATE->value);
+    $user->assignRole($role);
+
+    expect($user->can('create', DeviceSchemaVersion::class))->toBeTrue();
+});
+
+it('denies user without create permission to create schema versions', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->can('create', DeviceSchemaVersion::class))->toBeFalse();
+});
+
+it('allows user with update permission to update a schema version', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Editor', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaVersionPermission::UPDATE->value);
+    $user->assignRole($role);
+
+    $version = DeviceSchemaVersion::factory()->create();
+
+    expect($user->can('update', $version))->toBeTrue();
+});
+
+it('denies user without update permission to update a schema version', function (): void {
+    $user = User::factory()->create();
+    $version = DeviceSchemaVersion::factory()->create();
+
+    expect($user->can('update', $version))->toBeFalse();
+});
+
+it('allows user with delete permission to delete a schema version', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+    $role->givePermissionTo(DeviceSchemaVersionPermission::DELETE->value);
+    $user->assignRole($role);
+
+    $version = DeviceSchemaVersion::factory()->create();
+
+    expect($user->can('delete', $version))->toBeTrue();
+});
+
+it('denies user without delete permission to delete a schema version', function (): void {
+    $user = User::factory()->create();
+    $version = DeviceSchemaVersion::factory()->create();
+
+    expect($user->can('delete', $version))->toBeFalse();
+});
+
+it('super admin can perform all actions on schema versions', function (): void {
+    $superAdmin = User::factory()->create(['is_super_admin' => true]);
+    $version = DeviceSchemaVersion::factory()->create();
+
+    expect($superAdmin->can('viewAny', DeviceSchemaVersion::class))->toBeTrue()
+        ->and($superAdmin->can('view', $version))->toBeTrue()
+        ->and($superAdmin->can('create', DeviceSchemaVersion::class))->toBeTrue()
+        ->and($superAdmin->can('update', $version))->toBeTrue()
+        ->and($superAdmin->can('delete', $version))->toBeTrue();
+});

--- a/tests/Feature/Policies/ParameterDefinitionPolicyTest.php
+++ b/tests/Feature/Policies/ParameterDefinitionPolicyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\IoT\Models\ParameterDefinition;
+use App\Domain\IoT\Permissions\ParameterDefinitionPermission;
+use App\Domain\Shared\Models\Organization;
+use App\Domain\Shared\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function (): void {
+    $organization = Organization::factory()->create();
+    setPermissionsTeamId($organization->id);
+
+    foreach (ParameterDefinitionPermission::cases() as $permission) {
+        Permission::findOrCreate($permission->value, 'web');
+    }
+});
+
+it('allows user with viewAny permission to view parameter definitions index', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Viewer', 'guard_name' => 'web']);
+    $role->givePermissionTo(ParameterDefinitionPermission::VIEW_ANY->value);
+    $user->assignRole($role);
+
+    expect($user->can('viewAny', ParameterDefinition::class))->toBeTrue();
+});
+
+it('denies user without viewAny permission to view parameter definitions index', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->can('viewAny', ParameterDefinition::class))->toBeFalse();
+});
+
+it('allows user with view permission to view a parameter definition', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Viewer', 'guard_name' => 'web']);
+    $role->givePermissionTo(ParameterDefinitionPermission::VIEW->value);
+    $user->assignRole($role);
+
+    $parameter = ParameterDefinition::factory()->create();
+
+    expect($user->can('view', $parameter))->toBeTrue();
+});
+
+it('denies user without view permission to view a parameter definition', function (): void {
+    $user = User::factory()->create();
+    $parameter = ParameterDefinition::factory()->create();
+
+    expect($user->can('view', $parameter))->toBeFalse();
+});
+
+it('allows user with create permission to create parameter definitions', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Creator', 'guard_name' => 'web']);
+    $role->givePermissionTo(ParameterDefinitionPermission::CREATE->value);
+    $user->assignRole($role);
+
+    expect($user->can('create', ParameterDefinition::class))->toBeTrue();
+});
+
+it('denies user without create permission to create parameter definitions', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->can('create', ParameterDefinition::class))->toBeFalse();
+});
+
+it('allows user with update permission to update a parameter definition', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Editor', 'guard_name' => 'web']);
+    $role->givePermissionTo(ParameterDefinitionPermission::UPDATE->value);
+    $user->assignRole($role);
+
+    $parameter = ParameterDefinition::factory()->create();
+
+    expect($user->can('update', $parameter))->toBeTrue();
+});
+
+it('denies user without update permission to update a parameter definition', function (): void {
+    $user = User::factory()->create();
+    $parameter = ParameterDefinition::factory()->create();
+
+    expect($user->can('update', $parameter))->toBeFalse();
+});
+
+it('allows user with delete permission to delete a parameter definition', function (): void {
+    $user = User::factory()->create();
+    $role = Role::create(['name' => 'Admin', 'guard_name' => 'web']);
+    $role->givePermissionTo(ParameterDefinitionPermission::DELETE->value);
+    $user->assignRole($role);
+
+    $parameter = ParameterDefinition::factory()->create();
+
+    expect($user->can('delete', $parameter))->toBeTrue();
+});
+
+it('denies user without delete permission to delete a parameter definition', function (): void {
+    $user = User::factory()->create();
+    $parameter = ParameterDefinition::factory()->create();
+
+    expect($user->can('delete', $parameter))->toBeFalse();
+});
+
+it('super admin can perform all actions on parameter definitions', function (): void {
+    $superAdmin = User::factory()->create(['is_super_admin' => true]);
+    $parameter = ParameterDefinition::factory()->create();
+
+    expect($superAdmin->can('viewAny', ParameterDefinition::class))->toBeTrue()
+        ->and($superAdmin->can('view', $parameter))->toBeTrue()
+        ->and($superAdmin->can('create', ParameterDefinition::class))->toBeTrue()
+        ->and($superAdmin->can('update', $parameter))->toBeTrue()
+        ->and($superAdmin->can('delete', $parameter))->toBeTrue();
+});

--- a/tests/Unit/ParameterDefinitionTest.php
+++ b/tests/Unit/ParameterDefinitionTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\IoT\Enums\ParameterDataType;
+use App\Domain\IoT\Models\ParameterDefinition;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+it('extracts values from payloads using json path', function (): void {
+    $definition = new ParameterDefinition([
+        'json_path' => '$.status.temp',
+        'type' => ParameterDataType::Decimal,
+    ]);
+
+    $payload = [
+        'status' => [
+            'temp' => 22.5,
+        ],
+    ];
+
+    expect($definition->extractValue($payload))->toBe(22.5);
+});
+
+it('applies JsonLogic mutation expressions to values', function (): void {
+    $definition = new ParameterDefinition([
+        'json_path' => 'temp_c',
+        'type' => ParameterDataType::Decimal,
+        'mutation_expression' => [
+            '+' => [
+                ['*' => [
+                    ['var' => 'val'],
+                    1.8,
+                ]],
+                32,
+            ],
+        ],
+    ]);
+
+    $payload = ['temp_c' => 10];
+    $value = $definition->extractValue($payload);
+
+    expect($definition->mutateValue($value))->toBe(50.0);
+});
+
+it('validates required and critical flags', function (): void {
+    $definition = new ParameterDefinition([
+        'required' => true,
+        'is_critical' => true,
+        'type' => ParameterDataType::Integer,
+        'validation_error_code' => 'REQUIRED',
+    ]);
+
+    $result = $definition->validateValue(null);
+
+    expect($result['is_valid'])->toBeFalse()
+        ->and($result['is_critical'])->toBeTrue()
+        ->and($result['error_code'])->toBe('REQUIRED');
+});


### PR DESCRIPTION
## 🎯 Issue Reference
Closes #7

## 📝 Description
- Added device schema, schema version, and parameter definition models/migrations with constraints.
- Implemented JsonLogic-based mutation evaluation and validation helpers.
- Added IoT Filament resources and relation managers for schema versions and parameters.
- Added permissions, policies, factories, seed data, and tests for US-2.

## ✅ Checklist
- [x] All commits follow `US-<issue-number>: <description>` format
- [x] Tests added/updated and passing (`php artisan test --compact`)
- [x] Code formatted with Pint (`vendor/bin/pint --dirty --format agent`)
- [x] Static analysis passes (`vendor/bin/phpstan analyse`)
- [ ] Database migrations tested (up and down)
- [ ] Filament resources manually tested in browser
- [ ] Documentation updated (if needed)

## 🧪 Testing Instructions
1. `composer x`
2. `php artisan migrate:fresh --seed`

## 📸 Screenshots (if UI changes)
- N/A

## 🔗 Related Issues/PRs
- N/A

---
**⚠️ Remember**: This PR should be based on `main` and will be merged back into `main`.
