### PR TITLE
US-13: Device Registration and Telemetry Logging (TimescaleDB) #13 #17

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,6 +68,11 @@ This project has domain-specific skills available. You MUST activate the relevan
 
 - Laravel Boost is an MCP server that comes with powerful tools designed specifically for this application. Use them.
 
+## Verification & Static Analysis
+
+- ALWAYS run `composer x` before finalizing any changes. This command runs both Laravel Pint (code formatting) and Larastan (static analysis). You must fix any reported errors before completing the task.
+- If `composer x` reports errors you cannot fix easily, mention them to the user.
+
 ## Artisan
 
 - Use the `list-artisan-commands` tool when you need to call an Artisan command to double-check the available parameters.

--- a/app/Domain/IoT/Enums/ValidationStatus.php
+++ b/app/Domain/IoT/Enums/ValidationStatus.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Enums;
+
+enum ValidationStatus: string
+{
+    case Valid = 'valid';
+    case Invalid = 'invalid';
+    case Warning = 'warning';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Valid => 'Valid',
+            self::Invalid => 'Invalid',
+            self::Warning => 'Warning',
+        };
+    }
+}

--- a/app/Domain/IoT/Models/Device.php
+++ b/app/Domain/IoT/Models/Device.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Models;
+
+use App\Domain\DeviceTypes\Models\DeviceType;
+use App\Domain\Shared\Models\Organization;
+use Database\Factories\Domain\IoT\Models\DeviceFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Str;
+
+class Device extends Model
+{
+    /** @use HasFactory<\Database\Factories\Domain\IoT\Models\DeviceFactory> */
+    use HasFactory;
+
+    use SoftDeletes;
+
+    protected $guarded = ['id'];
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::creating(function (self $device): void {
+            if (! $device->uuid) {
+                $device->uuid = (string) Str::uuid();
+            }
+        });
+    }
+
+    protected static function newFactory(): DeviceFactory
+    {
+        return DeviceFactory::new();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_simulated' => 'bool',
+            'last_seen_at' => 'datetime',
+            'metadata' => 'array',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Organization, $this>
+     */
+    public function organization(): BelongsTo
+    {
+        return $this->belongsTo(Organization::class);
+    }
+
+    /**
+     * @return BelongsTo<DeviceType, $this>
+     */
+    public function deviceType(): BelongsTo
+    {
+        return $this->belongsTo(DeviceType::class);
+    }
+
+    /**
+     * @return BelongsTo<DeviceSchemaVersion, $this>
+     */
+    public function schemaVersion(): BelongsTo
+    {
+        return $this->belongsTo(DeviceSchemaVersion::class, 'device_schema_version_id');
+    }
+
+    /**
+     * @return HasMany<DeviceTelemetryLog, $this>
+     */
+    public function telemetryLogs(): HasMany
+    {
+        return $this->hasMany(DeviceTelemetryLog::class);
+    }
+}

--- a/app/Domain/IoT/Models/DeviceSchemaVersion.php
+++ b/app/Domain/IoT/Models/DeviceSchemaVersion.php
@@ -40,6 +40,14 @@ class DeviceSchemaVersion extends Model
         return $this->hasMany(DerivedParameterDefinition::class, 'device_schema_version_id');
     }
 
+    /**
+     * @return HasMany<DeviceTelemetryLog, $this>
+     */
+    public function telemetryLogs(): HasMany
+    {
+        return $this->hasMany(DeviceTelemetryLog::class, 'device_schema_version_id');
+    }
+
     public function isActive(): bool
     {
         return $this->status === 'active';

--- a/app/Domain/IoT/Models/DeviceTelemetryLog.php
+++ b/app/Domain/IoT/Models/DeviceTelemetryLog.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Models;
+
+use App\Domain\IoT\Enums\ValidationStatus;
+use Database\Factories\Domain\IoT\Models\DeviceTelemetryLogFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DeviceTelemetryLog extends Model
+{
+    /** @use HasFactory<\Database\Factories\Domain\IoT\Models\DeviceTelemetryLogFactory> */
+    use HasFactory;
+
+    use HasUuids;
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    protected $guarded = ['id'];
+
+    protected static function newFactory(): DeviceTelemetryLogFactory
+    {
+        return DeviceTelemetryLogFactory::new();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'raw_payload' => 'array',
+            'transformed_values' => 'array',
+            'validation_status' => ValidationStatus::class,
+            'recorded_at' => 'datetime',
+            'received_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * @return BelongsTo<Device, $this>
+     */
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(Device::class);
+    }
+
+    /**
+     * @return BelongsTo<DeviceSchemaVersion, $this>
+     */
+    public function schemaVersion(): BelongsTo
+    {
+        return $this->belongsTo(DeviceSchemaVersion::class, 'device_schema_version_id');
+    }
+}

--- a/app/Domain/IoT/Permissions/DevicePermission.php
+++ b/app/Domain/IoT/Permissions/DevicePermission.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Permissions;
+
+use Althinect\EnumPermission\Concerns\HasPermissionGroup;
+
+enum DevicePermission: string
+{
+    use HasPermissionGroup;
+
+    case VIEW_ANY = 'Device.view-any';
+    case VIEW = 'Device.view';
+    case CREATE = 'Device.create';
+    case UPDATE = 'Device.update';
+    case DELETE = 'Device.delete';
+    case RESTORE = 'Device.restore';
+    case FORCE_DELETE = 'Device.force-delete';
+}

--- a/app/Domain/IoT/Permissions/DeviceTelemetryLogPermission.php
+++ b/app/Domain/IoT/Permissions/DeviceTelemetryLogPermission.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Permissions;
+
+use Althinect\EnumPermission\Concerns\HasPermissionGroup;
+
+enum DeviceTelemetryLogPermission: string
+{
+    use HasPermissionGroup;
+
+    case VIEW_ANY = 'DeviceTelemetryLog.view-any';
+    case VIEW = 'DeviceTelemetryLog.view';
+    case CREATE = 'DeviceTelemetryLog.create';
+    case UPDATE = 'DeviceTelemetryLog.update';
+    case DELETE = 'DeviceTelemetryLog.delete';
+    case RESTORE = 'DeviceTelemetryLog.restore';
+    case FORCE_DELETE = 'DeviceTelemetryLog.force-delete';
+}

--- a/app/Domain/IoT/Support/TelemetryLogRecorder.php
+++ b/app/Domain/IoT/Support/TelemetryLogRecorder.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\IoT\Support;
+
+use App\Domain\IoT\Enums\ValidationStatus;
+use App\Domain\IoT\Models\DerivedParameterDefinition;
+use App\Domain\IoT\Models\Device;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\IoT\Models\DeviceTelemetryLog;
+use App\Domain\IoT\Models\ParameterDefinition;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+use RuntimeException;
+
+class TelemetryLogRecorder
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function record(Device $device, array $payload, ?Carbon $recordedAt = null, ?Carbon $receivedAt = null): DeviceTelemetryLog
+    {
+        $device->loadMissing('schemaVersion');
+
+        $schemaVersion = $device->schemaVersion;
+
+        if (! $schemaVersion instanceof DeviceSchemaVersion) {
+            throw new RuntimeException('Device schema version is required to record telemetry logs.');
+        }
+
+        $parameters = $schemaVersion->parameters()
+            ->where('is_active', true)
+            ->orderBy('sequence')
+            ->get();
+
+        $derivedParameters = $schemaVersion->derivedParameters()->get();
+
+        [$transformedValues, $validationStatus] = $this->evaluatePayload($payload, $parameters, $derivedParameters);
+
+        $resolvedReceivedAt = $receivedAt ?? Carbon::now();
+        $resolvedRecordedAt = $recordedAt ?? $resolvedReceivedAt;
+
+        return DeviceTelemetryLog::create([
+            'device_id' => $device->id,
+            'device_schema_version_id' => $schemaVersion->id,
+            'raw_payload' => $payload,
+            'transformed_values' => $transformedValues,
+            'validation_status' => $validationStatus,
+            'recorded_at' => $resolvedRecordedAt,
+            'received_at' => $resolvedReceivedAt,
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  Collection<int, ParameterDefinition>  $parameters
+     * @param  Collection<int, DerivedParameterDefinition>  $derivedParameters
+     * @return array{0: array<string, mixed>, 1: ValidationStatus}
+     */
+    private function evaluatePayload(array $payload, Collection $parameters, Collection $derivedParameters): array
+    {
+        $transformedValues = [];
+        $hasInvalid = false;
+        $hasCriticalInvalid = false;
+
+        foreach ($parameters as $parameter) {
+            $result = $parameter->evaluatePayload($payload);
+
+            $transformedValues[$parameter->key] = $result['mutated'];
+
+            if ($result['validation']['is_valid'] === false) {
+                $hasInvalid = true;
+
+                if ($result['validation']['is_critical'] === true) {
+                    $hasCriticalInvalid = true;
+                }
+            }
+        }
+
+        $derivedValues = $this->evaluateDerivedParameters($derivedParameters, $transformedValues);
+
+        $transformedValues = array_merge($transformedValues, $derivedValues);
+
+        $status = match (true) {
+            $hasCriticalInvalid => ValidationStatus::Invalid,
+            $hasInvalid => ValidationStatus::Warning,
+            default => ValidationStatus::Valid,
+        };
+
+        return [$transformedValues, $status];
+    }
+
+    /**
+     * @param  Collection<int, DerivedParameterDefinition>  $derivedParameters
+     * @param  array<string, mixed>  $inputs
+     * @return array<string, mixed>
+     */
+    private function evaluateDerivedParameters(Collection $derivedParameters, array $inputs): array
+    {
+        $pending = $derivedParameters->keyBy('key')->all();
+        $resolved = $inputs;
+        $derivedValues = [];
+        $maxIterations = count($pending);
+        $iterations = 0;
+
+        while ($pending !== [] && $iterations < $maxIterations) {
+            $progress = false;
+
+            foreach ($pending as $key => $definition) {
+                $dependencies = $definition->resolvedDependencies();
+
+                if (array_diff($dependencies, array_keys($resolved)) !== []) {
+                    continue;
+                }
+
+                $value = $definition->evaluate($resolved);
+                $derivedValues[$key] = $value;
+                $resolved[$key] = $value;
+                unset($pending[$key]);
+                $progress = true;
+            }
+
+            if (! $progress) {
+                break;
+            }
+
+            $iterations++;
+        }
+
+        return $derivedValues;
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/DeviceTelemetryLogResource.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/DeviceTelemetryLogResource.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs;
+
+use App\Domain\IoT\Models\DeviceTelemetryLog;
+use App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Pages\ListDeviceTelemetryLogs;
+use App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Pages\ViewDeviceTelemetryLog;
+use App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Schemas\DeviceTelemetryLogInfolist;
+use App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Tables\DeviceTelemetryLogsTable;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class DeviceTelemetryLogResource extends Resource
+{
+    protected static ?string $model = DeviceTelemetryLog::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedChartBar;
+
+    protected static ?int $navigationSort = 4;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('IoT Management');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Telemetry Logs');
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return DeviceTelemetryLogInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return DeviceTelemetryLogsTable::configure($table)
+            ->modifyQueryUsing(fn ($query) => $query->with(['device', 'schemaVersion']));
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListDeviceTelemetryLogs::route('/'),
+            'view' => ViewDeviceTelemetryLog::route('/{record}'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Pages/ListDeviceTelemetryLogs.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Pages/ListDeviceTelemetryLogs.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\DeviceTelemetryLogResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDeviceTelemetryLogs extends ListRecords
+{
+    protected static string $resource = DeviceTelemetryLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Pages/ViewDeviceTelemetryLog.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Pages/ViewDeviceTelemetryLog.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Pages;
+
+use App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\DeviceTelemetryLogResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDeviceTelemetryLog extends ViewRecord
+{
+    protected static string $resource = DeviceTelemetryLogResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Schemas/DeviceTelemetryLogInfolist.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Schemas/DeviceTelemetryLogInfolist.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Schemas;
+
+use App\Domain\IoT\Enums\ValidationStatus;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+
+class DeviceTelemetryLogInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make('Device')
+                    ->schema([
+                        TextEntry::make('device.name')
+                            ->label('Device Name')
+                            ->weight('medium')
+                            ->icon(Heroicon::OutlinedCpuChip),
+                        TextEntry::make('device.uuid')
+                            ->label('Device UUID')
+                            ->icon(Heroicon::OutlinedIdentification),
+                        TextEntry::make('schemaVersion.version')
+                            ->label('Schema Version')
+                            ->icon(Heroicon::OutlinedDocumentText),
+                    ])
+                    ->columns(3),
+
+                Section::make('Telemetry')
+                    ->schema([
+                        TextEntry::make('validation_status')
+                            ->label('Validation Status')
+                            ->badge()
+                            ->formatStateUsing(fn (ValidationStatus|string $state): string => $state instanceof ValidationStatus ? $state->label() : (string) $state),
+                        TextEntry::make('recorded_at')
+                            ->dateTime()
+                            ->icon(Heroicon::OutlinedClock),
+                        TextEntry::make('received_at')
+                            ->dateTime()
+                            ->icon(Heroicon::OutlinedClock),
+                    ])
+                    ->columns(3),
+
+                Section::make('Payloads')
+                    ->schema([
+                        TextEntry::make('raw_payload')
+                            ->label('Raw Payload')
+                            ->formatStateUsing(fn (mixed $state): ?string => self::formatJson($state))
+                            ->extraAttributes(['class' => 'font-mono whitespace-pre-wrap'])
+                            ->columnSpanFull(),
+                        TextEntry::make('transformed_values')
+                            ->label('Transformed Values')
+                            ->formatStateUsing(fn (mixed $state): ?string => self::formatJson($state))
+                            ->extraAttributes(['class' => 'font-mono whitespace-pre-wrap'])
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    private static function formatJson(mixed $state): ?string
+    {
+        if (is_array($state)) {
+            $encoded = json_encode($state, JSON_PRETTY_PRINT);
+
+            return $encoded === false ? null : $encoded;
+        }
+
+        return is_string($state) ? $state : null;
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Tables/DeviceTelemetryLogsTable.php
+++ b/app/Filament/Admin/Resources/IoT/DeviceTelemetryLogs/Tables/DeviceTelemetryLogsTable.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Tables;
+
+use App\Domain\IoT\Enums\ValidationStatus;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class DeviceTelemetryLogsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('device.uuid')
+                    ->label('Device UUID')
+                    ->searchable()
+                    ->copyable(),
+
+                TextColumn::make('device.name')
+                    ->label('Device Name')
+                    ->searchable(),
+
+                TextColumn::make('schemaVersion.version')
+                    ->label('Schema Version')
+                    ->sortable(),
+
+                TextColumn::make('validation_status')
+                    ->badge()
+                    ->formatStateUsing(fn (ValidationStatus|string $state): string => $state instanceof ValidationStatus ? $state->label() : (string) $state),
+
+                TextColumn::make('recorded_at')
+                    ->dateTime()
+                    ->sortable(),
+
+                TextColumn::make('received_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('validation_status')
+                    ->label('Validation Status')
+                    ->options(ValidationStatus::class),
+
+                Filter::make('recorded_at')
+                    ->form([
+                        DateTimePicker::make('from')
+                            ->label('From'),
+                        DateTimePicker::make('until')
+                            ->label('Until'),
+                    ])
+                    ->query(function (Builder $query, array $data): Builder {
+                        $query->when(
+                            $data['from'] ?? null,
+                            fn (Builder $query, $date): Builder => $query->where('recorded_at', '>=', $date),
+                        );
+
+                        return $query->when(
+                            $data['until'] ?? null,
+                            fn (Builder $query, $date): Builder => $query->where('recorded_at', '<=', $date),
+                        );
+                    }),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+            ])
+            ->defaultSort('recorded_at', 'desc');
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/DeviceResource.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/DeviceResource.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\Devices;
+
+use App\Domain\IoT\Models\Device;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class DeviceResource extends Resource
+{
+    protected static ?string $model = Device::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCpuChip;
+
+    protected static ?int $navigationSort = 2;
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('IoT Management');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Devices');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return Schemas\DeviceForm::configure($schema);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return Schemas\DeviceInfolist::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return Tables\DevicesTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            RelationManagers\TelemetryLogsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDevices::route('/'),
+            'create' => Pages\CreateDevice::route('/create'),
+            'view' => Pages\ViewDevice::route('/{record}'),
+            'edit' => Pages\EditDevice::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/Pages/CreateDevice.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/Pages/CreateDevice.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\IoT\Devices\Pages;
+
+use App\Filament\Admin\Resources\IoT\Devices\DeviceResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDevice extends CreateRecord
+{
+    protected static string $resource = DeviceResource::class;
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/Pages/EditDevice.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/Pages/EditDevice.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Admin\Resources\IoT\Devices\Pages;
+
+use App\Filament\Admin\Resources\IoT\Devices\DeviceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDevice extends EditRecord
+{
+    protected static string $resource = DeviceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/Pages/ListDevices.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/Pages/ListDevices.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\IoT\Devices\Pages;
+
+use App\Filament\Admin\Resources\IoT\Devices\DeviceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDevices extends ListRecords
+{
+    protected static string $resource = DeviceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/Pages/ViewDevice.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/Pages/ViewDevice.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\IoT\Devices\Pages;
+
+use App\Filament\Admin\Resources\IoT\Devices\DeviceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDevice extends ViewRecord
+{
+    protected static string $resource = DeviceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/RelationManagers/TelemetryLogsRelationManager.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/RelationManagers/TelemetryLogsRelationManager.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\Devices\RelationManagers;
+
+use App\Filament\Admin\Resources\IoT\DeviceTelemetryLogs\Tables\DeviceTelemetryLogsTable;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
+
+class TelemetryLogsRelationManager extends RelationManager
+{
+    protected static string $relationship = 'telemetryLogs';
+
+    public function form(Schema $schema): Schema
+    {
+        return $schema; // Read-only
+    }
+
+    public function table(Table $table): Table
+    {
+        return DeviceTelemetryLogsTable::configure($table);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/Schemas/DeviceForm.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/Schemas/DeviceForm.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\Devices\Schemas;
+
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+
+class DeviceForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                Section::make('Identity')
+                    ->schema([
+                        TextInput::make('name')
+                            ->required()
+                            ->maxLength(255),
+
+                        TextInput::make('uuid')
+                            ->label('UUID')
+                            ->disabled()
+                            ->dehydrated(false)
+                            ->visible(fn ($record) => $record !== null),
+
+                        TextInput::make('external_id')
+                            ->label('External ID')
+                            ->maxLength(255)
+                            ->helperText('Product serial number or hardware ID'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Configuration')
+                    ->schema([
+                        Select::make('organization_id')
+                            ->relationship('organization', 'name')
+                            ->required()
+                            ->searchable()
+                            ->preload(),
+
+                        Select::make('device_type_id')
+                            ->label('Device Type')
+                            ->relationship('deviceType', 'name')
+                            ->required()
+                            ->searchable()
+                            ->preload()
+                            ->live(),
+
+                        Select::make('device_schema_version_id')
+                            ->label('Schema Version')
+                            ->options(fn (Get $get) => DeviceSchemaVersion::query()
+                                ->whereHas('schema', fn ($query) => $query->where('device_type_id', $get('device_type_id')))
+                                ->where('status', 'active')
+                                ->pluck('version', 'id')
+                                ->map(fn (mixed $version): string => 'Version '.(is_scalar($version) ? (string) $version : ''))
+                                ->toArray())
+                            ->required()
+                            ->searchable()
+                            ->preload()
+                            ->disabled(fn (Get $get) => ! $get('device_type_id'))
+                            ->helperText('Only active schema versions for the selected device type are shown'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Status & Simulation')
+                    ->schema([
+                        Toggle::make('is_active')
+                            ->label('Is Active')
+                            ->default(true),
+
+                        Toggle::make('is_simulated')
+                            ->label('Is Simulated')
+                            ->default(false),
+
+                        TextInput::make('connection_state')
+                            ->label('Connection State')
+                            ->disabled()
+                            ->placeholder('Unknown'),
+
+                        TextInput::make('last_seen_at')
+                            ->label('Last Seen At')
+                            ->disabled()
+                            ->placeholder('Never'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Metadata')
+                    ->schema([
+                        KeyValue::make('metadata')
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/Schemas/DeviceInfolist.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/Schemas/DeviceInfolist.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\Devices\Schemas;
+
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\KeyValueEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Colors\Color;
+
+class DeviceInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                Section::make('Device Details')
+                    ->schema([
+                        TextEntry::make('name')
+                            ->weight('bold'),
+
+                        TextEntry::make('uuid')
+                            ->label('UUID')
+                            ->copyable(),
+
+                        TextEntry::make('external_id')
+                            ->label('External ID')
+                            ->placeholder('None'),
+
+                        TextEntry::make('organization.name')
+                            ->label('Organization'),
+
+                        TextEntry::make('deviceType.name')
+                            ->label('Device Type'),
+
+                        TextEntry::make('schemaVersion.version')
+                            ->label('Schema Version')
+                            ->formatStateUsing(fn ($state) => "Version {$state}"),
+                    ])
+                    ->columns(2),
+
+                Section::make('Status')
+                    ->schema([
+                        IconEntry::make('is_active')
+                            ->label('Active')
+                            ->boolean(),
+
+                        IconEntry::make('is_simulated')
+                            ->label('Simulated')
+                            ->boolean(),
+
+                        TextEntry::make('connection_state')
+                            ->label('Connection State')
+                            ->badge()
+                            ->color(fn ($state) => match ($state) {
+                                'online' => Color::Green,
+                                'offline' => Color::Red,
+                                default => Color::Gray,
+                            })
+                            ->placeholder('Unknown'),
+
+                        TextEntry::make('last_seen_at')
+                            ->label('Last Seen')
+                            ->dateTime()
+                            ->placeholder('Never'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Metadata')
+                    ->schema([
+                        KeyValueEntry::make('metadata')
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/IoT/Devices/Tables/DevicesTable.php
+++ b/app/Filament/Admin/Resources/IoT/Devices/Tables/DevicesTable.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Admin\Resources\IoT\Devices\Tables;
+
+use Filament\Actions;
+use Filament\Support\Colors\Color;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class DevicesTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable()
+                    ->weight('medium')
+                    ->description(fn ($record) => $record->uuid),
+
+                TextColumn::make('organization.name')
+                    ->label('Organization')
+                    ->searchable()
+                    ->sortable(),
+
+                TextColumn::make('deviceType.name')
+                    ->label('Type')
+                    ->searchable()
+                    ->sortable(),
+
+                IconColumn::make('is_active')
+                    ->label('Active')
+                    ->boolean()
+                    ->sortable(),
+
+                IconColumn::make('is_simulated')
+                    ->label('Simulated')
+                    ->boolean()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+
+                TextColumn::make('connection_state')
+                    ->label('Status')
+                    ->badge()
+                    ->color(fn ($state) => match ($state) {
+                        'online' => Color::Green,
+                        'offline' => Color::Red,
+                        default => Color::Gray,
+                    })
+                    ->sortable(),
+
+                TextColumn::make('last_seen_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                SelectFilter::make('organization')
+                    ->relationship('organization', 'name')
+                    ->searchable()
+                    ->preload(),
+
+                SelectFilter::make('deviceType')
+                    ->relationship('deviceType', 'name')
+                    ->searchable()
+                    ->preload(),
+
+                SelectFilter::make('connection_state')
+                    ->options([
+                        'online' => 'Online',
+                        'offline' => 'Offline',
+                    ]),
+            ])
+            ->recordActions([
+                Actions\ViewAction::make(),
+                Actions\EditAction::make(),
+                Actions\DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                Actions\BulkActionGroup::make([
+                    Actions\DeleteBulkAction::make(),
+                ]),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+}

--- a/app/Filament/Portal/Resources/IoT/Devices/DeviceResource.php
+++ b/app/Filament/Portal/Resources/IoT/Devices/DeviceResource.php
@@ -1,0 +1,240 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Portal\Resources\IoT\Devices;
+
+use App\Domain\IoT\Models\Device;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Filament\Admin\Resources\IoT\Devices\RelationManagers\TelemetryLogsRelationManager;
+use BackedEnum;
+use Filament\Actions\EditAction;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
+use Filament\Infolists\Components\IconEntry;
+use Filament\Infolists\Components\KeyValueEntry;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Support\Colors\Color;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\IconColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+
+class DeviceResource extends Resource
+{
+    protected static ?string $model = Device::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedCpuChip;
+
+    protected static ?string $tenantOwnershipRelationshipName = 'organization';
+
+    public static function getNavigationGroup(): ?string
+    {
+        return __('IoT Management');
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return __('Devices');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                Section::make('Identity')
+                    ->schema([
+                        TextInput::make('name')
+                            ->required()
+                            ->maxLength(255),
+
+                        TextInput::make('uuid')
+                            ->label('UUID')
+                            ->disabled()
+                            ->dehydrated(false)
+                            ->visible(fn ($record) => $record !== null),
+
+                        TextInput::make('external_id')
+                            ->label('External ID')
+                            ->maxLength(255),
+                    ])
+                    ->columns(2),
+
+                Section::make('Configuration')
+                    ->schema([
+                        Select::make('device_type_id')
+                            ->label('Device Type')
+                            ->relationship('deviceType', 'name')
+                            ->required()
+                            ->searchable()
+                            ->preload()
+                            ->live(),
+
+                        Select::make('device_schema_version_id')
+                            ->label('Schema Version')
+                            ->options(fn (Get $get) => DeviceSchemaVersion::query()
+                                ->whereHas('schema', fn ($query) => $query->where('device_type_id', $get('device_type_id')))
+                                ->where('status', 'active')
+                                ->pluck('version', 'id')
+                                ->map(fn (mixed $version): string => 'Version '.(is_scalar($version) ? (string) $version : ''))
+                                ->toArray())
+                            ->required()
+                            ->searchable()
+                            ->preload()
+                            ->disabled(fn (Get $get) => ! $get('device_type_id')),
+                    ])
+                    ->columns(2),
+
+                Section::make('Status')
+                    ->schema([
+                        Toggle::make('is_active')
+                            ->label('Is Active')
+                            ->default(true),
+
+                        TextInput::make('connection_state')
+                            ->label('Connection State')
+                            ->disabled()
+                            ->placeholder('Unknown'),
+
+                        TextInput::make('last_seen_at')
+                            ->label('Last Seen At')
+                            ->disabled()
+                            ->placeholder('Never'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Metadata')
+                    ->schema([
+                        KeyValue::make('metadata')
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    public static function infolist(Schema $schema): Schema
+    {
+        return $schema
+            ->columns(2)
+            ->components([
+                Section::make('Device Details')
+                    ->schema([
+                        TextEntry::make('name')
+                            ->weight('bold'),
+
+                        TextEntry::make('uuid')
+                            ->label('UUID')
+                            ->copyable(),
+
+                        TextEntry::make('external_id')
+                            ->label('External ID'),
+
+                        TextEntry::make('deviceType.name')
+                            ->label('Device Type'),
+
+                        TextEntry::make('schemaVersion.version')
+                            ->label('Schema Version')
+                            ->formatStateUsing(fn ($state) => "Version {$state}"),
+                    ])
+                    ->columns(2),
+
+                Section::make('Status')
+                    ->schema([
+                        IconEntry::make('is_active')
+                            ->label('Active')
+                            ->boolean(),
+
+                        TextEntry::make('connection_state')
+                            ->label('Connection State')
+                            ->badge()
+                            ->color(fn ($state) => match ($state) {
+                                'online' => Color::Green,
+                                'offline' => Color::Red,
+                                default => Color::Gray,
+                            }),
+
+                        TextEntry::make('last_seen_at')
+                            ->label('Last Seen')
+                            ->dateTime(),
+                    ])
+                    ->columns(2),
+
+                Section::make('Metadata')
+                    ->schema([
+                        KeyValueEntry::make('metadata')
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable()
+                    ->weight('medium'),
+
+                TextColumn::make('deviceType.name')
+                    ->label('Type')
+                    ->searchable()
+                    ->sortable(),
+
+                IconColumn::make('is_active')
+                    ->label('Active')
+                    ->boolean()
+                    ->sortable(),
+
+                TextColumn::make('connection_state')
+                    ->label('Status')
+                    ->badge()
+                    ->color(fn ($state) => match ($state) {
+                        'online' => Color::Green,
+                        'offline' => Color::Red,
+                        default => Color::Gray,
+                    })
+                    ->sortable(),
+
+                TextColumn::make('last_seen_at')
+                    ->dateTime()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('deviceType')
+                    ->relationship('deviceType', 'name')
+                    ->searchable()
+                    ->preload(),
+            ])
+            ->recordActions([
+                ViewAction::make(),
+                EditAction::make(),
+            ])
+            ->defaultSort('created_at', 'desc');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            TelemetryLogsRelationManager::class,
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDevices::route('/'),
+            'create' => Pages\CreateDevice::route('/create'),
+            'view' => Pages\ViewDevice::route('/{record}'),
+            'edit' => Pages\EditDevice::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Portal/Resources/IoT/Devices/Pages/CreateDevice.php
+++ b/app/Filament/Portal/Resources/IoT/Devices/Pages/CreateDevice.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Portal\Resources\IoT\Devices\Pages;
+
+use App\Filament\Portal\Resources\IoT\Devices\DeviceResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDevice extends CreateRecord
+{
+    protected static string $resource = DeviceResource::class;
+}

--- a/app/Filament/Portal/Resources/IoT/Devices/Pages/EditDevice.php
+++ b/app/Filament/Portal/Resources/IoT/Devices/Pages/EditDevice.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Filament\Portal\Resources\IoT\Devices\Pages;
+
+use App\Filament\Portal\Resources\IoT\Devices\DeviceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDevice extends EditRecord
+{
+    protected static string $resource = DeviceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\ViewAction::make(),
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Portal/Resources/IoT/Devices/Pages/ListDevices.php
+++ b/app/Filament/Portal/Resources/IoT/Devices/Pages/ListDevices.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Portal\Resources\IoT\Devices\Pages;
+
+use App\Filament\Portal\Resources\IoT\Devices\DeviceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDevices extends ListRecords
+{
+    protected static string $resource = DeviceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Portal/Resources/IoT/Devices/Pages/ViewDevice.php
+++ b/app/Filament/Portal/Resources/IoT/Devices/Pages/ViewDevice.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Portal\Resources\IoT\Devices\Pages;
+
+use App\Filament\Portal\Resources\IoT\Devices\DeviceResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewDevice extends ViewRecord
+{
+    protected static string $resource = DeviceResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\EditAction::make(),
+        ];
+    }
+}

--- a/app/Policies/DevicePolicy.php
+++ b/app/Policies/DevicePolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Domain\IoT\Models\Device;
+use App\Domain\IoT\Permissions\DevicePermission;
+use App\Domain\Shared\Models\User;
+
+class DevicePolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo(DevicePermission::VIEW_ANY);
+    }
+
+    public function view(User $user, Device $model): bool
+    {
+        return $user->hasPermissionTo(DevicePermission::VIEW);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo(DevicePermission::CREATE);
+    }
+
+    public function update(User $user, Device $model): bool
+    {
+        return $user->hasPermissionTo(DevicePermission::UPDATE);
+    }
+
+    public function delete(User $user, Device $model): bool
+    {
+        return $user->hasPermissionTo(DevicePermission::DELETE);
+    }
+
+    public function restore(User $user, Device $model): bool
+    {
+        return $user->hasPermissionTo(DevicePermission::RESTORE);
+    }
+
+    public function forceDelete(User $user, Device $model): bool
+    {
+        return $user->hasPermissionTo(DevicePermission::FORCE_DELETE);
+    }
+}

--- a/app/Policies/DeviceTelemetryLogPolicy.php
+++ b/app/Policies/DeviceTelemetryLogPolicy.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Policies;
+
+use App\Domain\IoT\Models\DeviceTelemetryLog;
+use App\Domain\IoT\Permissions\DeviceTelemetryLogPermission;
+use App\Domain\Shared\Models\User;
+
+class DeviceTelemetryLogPolicy
+{
+    public function viewAny(User $user): bool
+    {
+        return $user->hasPermissionTo(DeviceTelemetryLogPermission::VIEW_ANY);
+    }
+
+    public function view(User $user, DeviceTelemetryLog $deviceTelemetryLog): bool
+    {
+        return $user->hasPermissionTo(DeviceTelemetryLogPermission::VIEW);
+    }
+
+    public function create(User $user): bool
+    {
+        return $user->hasPermissionTo(DeviceTelemetryLogPermission::CREATE);
+    }
+
+    public function update(User $user, DeviceTelemetryLog $deviceTelemetryLog): bool
+    {
+        return $user->hasPermissionTo(DeviceTelemetryLogPermission::UPDATE);
+    }
+
+    public function delete(User $user, DeviceTelemetryLog $deviceTelemetryLog): bool
+    {
+        return $user->hasPermissionTo(DeviceTelemetryLogPermission::DELETE);
+    }
+
+    public function restore(User $user, DeviceTelemetryLog $deviceTelemetryLog): bool
+    {
+        return $user->hasPermissionTo(DeviceTelemetryLogPermission::RESTORE);
+    }
+
+    public function forceDelete(User $user, DeviceTelemetryLog $deviceTelemetryLog): bool
+    {
+        return $user->hasPermissionTo(DeviceTelemetryLogPermission::FORCE_DELETE);
+    }
+}

--- a/database/factories/Domain/IoT/Models/DeviceFactory.php
+++ b/database/factories/Domain/IoT/Models/DeviceFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Domain\IoT\Models;
+
+use App\Domain\DeviceTypes\Models\DeviceType;
+use App\Domain\IoT\Models\Device;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\Shared\Models\Organization;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Domain\IoT\Models\Device>
+ */
+class DeviceFactory extends Factory
+{
+    protected $model = Device::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'organization_id' => Organization::factory(),
+            'device_type_id' => DeviceType::factory(),
+            'device_schema_version_id' => DeviceSchemaVersion::factory(),
+            'uuid' => (string) Str::uuid(),
+            'name' => $this->faker->words(2, true),
+            'external_id' => $this->faker->optional()->bothify('EXT-####'),
+            'is_simulated' => $this->faker->boolean(10),
+            'connection_state' => $this->faker->randomElement(['online', 'offline', 'unknown']),
+            'last_seen_at' => $this->faker->optional()->dateTimeBetween('-7 days'),
+        ];
+    }
+}

--- a/database/factories/Domain/IoT/Models/DeviceTelemetryLogFactory.php
+++ b/database/factories/Domain/IoT/Models/DeviceTelemetryLogFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Domain\IoT\Models;
+
+use App\Domain\IoT\Enums\ValidationStatus;
+use App\Domain\IoT\Models\Device;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\IoT\Models\DeviceTelemetryLog;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Domain\IoT\Models\DeviceTelemetryLog>
+ */
+class DeviceTelemetryLogFactory extends Factory
+{
+    protected $model = DeviceTelemetryLog::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $receivedAt = $this->faker->dateTimeBetween('-1 day');
+        $recordedAt = $this->faker->dateTimeBetween('-1 day', $receivedAt);
+
+        return [
+            'device_id' => Device::factory(),
+            'device_schema_version_id' => DeviceSchemaVersion::factory(),
+            'raw_payload' => [
+                'temp' => $this->faker->randomFloat(2, -10, 40),
+                'voltage' => $this->faker->randomFloat(2, 100, 250),
+            ],
+            'transformed_values' => [
+                'temp' => $this->faker->randomFloat(2, -10, 40),
+                'voltage' => $this->faker->randomFloat(2, 100, 250),
+            ],
+            'validation_status' => $this->faker->randomElement(ValidationStatus::cases()),
+            'recorded_at' => $recordedAt,
+            'received_at' => $receivedAt,
+        ];
+    }
+
+    public function forDevice(Device $device): static
+    {
+        return $this->state(fn () => [
+            'device_id' => $device->id,
+            'device_schema_version_id' => $device->device_schema_version_id,
+        ]);
+    }
+}

--- a/database/migrations/2026_02_06_182306_create_devices_table.php
+++ b/database/migrations/2026_02_06_182306_create_devices_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('devices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('organization_id')->constrained();
+            $table->foreignId('device_type_id')->constrained('device_types');
+            $table->foreignId('device_schema_version_id')->constrained('device_schema_versions');
+            $table->uuid('uuid')->unique();
+            $table->string('name');
+            $table->string('external_id')->nullable();
+            $table->jsonb('metadata')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->boolean('is_simulated')->default(false);
+            $table->string('connection_state', 50)->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('devices');
+    }
+};

--- a/database/migrations/2026_02_06_182310_create_device_telemetry_logs_table.php
+++ b/database/migrations/2026_02_06_182310_create_device_telemetry_logs_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('device_telemetry_logs', function (Blueprint $table) {
+            $table->uuid('id');
+            $table->foreignId('device_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('device_schema_version_id')->constrained('device_schema_versions');
+            $table->string('validation_status', 50);
+            $table->jsonb('raw_payload');
+            $table->jsonb('transformed_values');
+            $table->timestamp('recorded_at');
+            $table->timestamp('received_at')->useCurrent();
+            $table->timestamps();
+
+            $table->primary(['id', 'recorded_at']);
+            $table->index('recorded_at');
+            $table->index('validation_status');
+        });
+
+        if (DB::getDriverName() === 'pgsql') {
+            DB::statement('CREATE EXTENSION IF NOT EXISTS timescaledb');
+            DB::statement("SELECT create_hypertable('device_telemetry_logs', 'recorded_at', if_not_exists => TRUE)");
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('device_telemetry_logs');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -37,6 +37,7 @@ class DatabaseSeeder extends Seeder
         $this->call([
             OrganizationSeeder::class,
             DeviceSchemaSeeder::class,
+            DeviceTelemetrySeeder::class,
         ]);
     }
 }

--- a/database/seeders/DeviceTelemetrySeeder.php
+++ b/database/seeders/DeviceTelemetrySeeder.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Seeders;
+
+use App\Domain\DeviceTypes\Models\DeviceType;
+use App\Domain\IoT\Models\Device;
+use App\Domain\IoT\Models\DeviceSchema;
+use App\Domain\IoT\Support\TelemetryLogRecorder;
+use App\Domain\Shared\Models\Organization;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Carbon;
+
+class DeviceTelemetrySeeder extends Seeder
+{
+    public function __construct(protected TelemetryLogRecorder $recorder) {}
+
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $organization = Organization::first() ?? Organization::factory()->create();
+
+        $deviceType = DeviceType::where('key', 'energy_meter')->first();
+
+        if (! $deviceType) {
+            $this->command->warn('Energy Meter DeviceType not found. Please run DeviceSchemaSeeder first.');
+
+            return;
+        }
+
+        $schema = DeviceSchema::where('device_type_id', $deviceType->id)->first();
+        $version = $schema?->versions()->where('status', 'active')->first();
+
+        if (! $version) {
+            $this->command->warn('Active schema version for Energy Meter not found.');
+
+            return;
+        }
+
+        $device = Device::firstOrCreate([
+            'organization_id' => $organization->id,
+            'device_type_id' => $deviceType->id,
+            'external_id' => 'main-energy-meter-01',
+        ], [
+            'name' => 'Main Building Energy Meter',
+            'device_schema_version_id' => $version->id,
+            'metadata' => [
+                'location' => 'Main Electrical Room',
+                'model' => 'EM-3PH-400',
+            ],
+            'is_active' => true,
+        ]);
+
+        $this->command->info("Generating telemetry history for device: {$device->name}");
+
+        $now = Carbon::now();
+        $startDate = $now->copy()->subDays(7)->startOfDay();
+        $totalSteps = (int) ($now->diffInMinutes($startDate) / 15);
+
+        $currentDate = $startDate->copy();
+
+        $bar = $this->command->getOutput()->createProgressBar($totalSteps);
+        $bar->start();
+
+        while ($currentDate->lessThanOrEqualTo($now)) {
+            // Simulate realistic energy data
+            $hour = (int) $currentDate->format('H');
+
+            // Base demand spikes during working hours (8 AM - 6 PM)
+            $loadMultiplier = ($hour >= 8 && $hour <= 18) ? 2.5 : 0.8;
+            $randomNoise = rand(80, 120) / 100;
+
+            $payload = [
+                'voltages' => [
+                    'V1' => 230 + (rand(-50, 50) / 10),
+                    'V2' => 229 + (rand(-50, 50) / 10),
+                    'V3' => 231 + (rand(-50, 50) / 10),
+                ],
+                'power' => [
+                    'power_l1' => (1500 * $loadMultiplier * $randomNoise) + rand(-100, 100),
+                    'power_l2' => (1200 * $loadMultiplier * $randomNoise) + rand(-100, 100),
+                    'power_l3' => (1800 * $loadMultiplier * $randomNoise) + rand(-100, 100),
+                ],
+            ];
+
+            // Ensure values are positive
+            $payload['power']['power_l1'] = max(0, $payload['power']['power_l1']);
+            $payload['power']['power_l2'] = max(0, $payload['power']['power_l2']);
+            $payload['power']['power_l3'] = max(0, $payload['power']['power_l3']);
+
+            $this->recorder->record(
+                device: $device,
+                payload: $payload,
+                recordedAt: $currentDate->copy(),
+                receivedAt: $currentDate->copy()->addSeconds(rand(1, 5))
+            );
+
+            $currentDate->addMinutes(15);
+            $bar->advance();
+        }
+
+        $bar->finish();
+        $this->command->newLine();
+        $this->command->info('Telemetry history generated successfully.');
+    }
+}

--- a/tests/Feature/DeviceTelemetryLogTest.php
+++ b/tests/Feature/DeviceTelemetryLogTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\IoT\Enums\ParameterDataType;
+use App\Domain\IoT\Enums\ValidationStatus;
+use App\Domain\IoT\Models\DerivedParameterDefinition;
+use App\Domain\IoT\Models\Device;
+use App\Domain\IoT\Models\DeviceSchemaVersion;
+use App\Domain\IoT\Models\DeviceTelemetryLog;
+use App\Domain\IoT\Models\ParameterDefinition;
+use App\Domain\IoT\Support\TelemetryLogRecorder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+it('persists raw and transformed telemetry payloads', function (): void {
+    $schemaVersion = DeviceSchemaVersion::factory()->create();
+
+    ParameterDefinition::factory()->create([
+        'device_schema_version_id' => $schemaVersion->id,
+        'key' => 'temp_c',
+        'json_path' => 'temp_c',
+        'type' => ParameterDataType::Decimal,
+        'required' => true,
+        'is_critical' => false,
+        'mutation_expression' => [
+            '+' => [
+                ['var' => 'val'],
+                1,
+            ],
+        ],
+        'sequence' => 1,
+        'is_active' => true,
+    ]);
+
+    DerivedParameterDefinition::factory()->create([
+        'device_schema_version_id' => $schemaVersion->id,
+        'key' => 'temp_f',
+        'data_type' => ParameterDataType::Decimal,
+        'expression' => [
+            '+' => [
+                [
+                    '*' => [
+                        ['var' => 'temp_c'],
+                        1.8,
+                    ],
+                ],
+                32,
+            ],
+        ],
+        'dependencies' => ['temp_c'],
+    ]);
+
+    $device = Device::factory()->create([
+        'device_schema_version_id' => $schemaVersion->id,
+    ]);
+
+    $payload = ['temp_c' => 10];
+    $recorder = new TelemetryLogRecorder;
+
+    $log = $recorder->record($device, $payload);
+
+    expect($log->raw_payload)->toBe($payload)
+        ->and($log->transformed_values)->toMatchArray([
+            'temp_c' => 11.0,
+            'temp_f' => 51.8,
+        ])
+        ->and($log->validation_status)->toBe(ValidationStatus::Valid);
+});
+
+it('marks telemetry as invalid when critical validation fails', function (): void {
+    $schemaVersion = DeviceSchemaVersion::factory()->create();
+
+    ParameterDefinition::factory()->create([
+        'device_schema_version_id' => $schemaVersion->id,
+        'key' => 'humidity',
+        'json_path' => 'humidity',
+        'type' => ParameterDataType::Decimal,
+        'required' => true,
+        'is_critical' => true,
+        'mutation_expression' => null,
+        'sequence' => 1,
+        'is_active' => true,
+    ]);
+
+    $device = Device::factory()->create([
+        'device_schema_version_id' => $schemaVersion->id,
+    ]);
+
+    $recorder = new TelemetryLogRecorder;
+
+    $log = $recorder->record($device, []);
+
+    expect($log->validation_status)->toBe(ValidationStatus::Invalid);
+});
+
+it('can filter telemetry logs by recorded time range', function (): void {
+    $device = Device::factory()->create();
+
+    DeviceTelemetryLog::factory()->forDevice($device)->create([
+        'recorded_at' => Carbon::parse('2026-02-06 09:00:00'),
+    ]);
+
+    DeviceTelemetryLog::factory()->forDevice($device)->create([
+        'recorded_at' => Carbon::parse('2026-02-06 11:00:00'),
+    ]);
+
+    $logs = DeviceTelemetryLog::query()
+        ->whereBetween('recorded_at', [
+            Carbon::parse('2026-02-06 10:00:00'),
+            Carbon::parse('2026-02-06 12:00:00'),
+        ])
+        ->get();
+
+    expect($logs)->toHaveCount(1)
+        ->and($logs->first()?->recorded_at?->toDateTimeString())->toBe('2026-02-06 11:00:00');
+});


### PR DESCRIPTION
## 🎯 Issue Reference
Closes #13
Closes #17

## 📝 Description
This PR implements the core IoT device management and telemetry logging system, including backend models, frontend Filament resources, and TimescaleDB integration.

### Core Changes:
- **Device Management**: Created `Device` model with UUID generation, organization scoping, and soft deletes.
- **Telemetry Logging**: Implemented `DeviceTelemetryLog` model designed for high-volume time-series data using **TimescaleDB hypertables**.
- **Ingestion Pipeline**: Added `TelemetryLogRecorder` for processing raw payloads, applying JsonLogic mutations, and validating data against schema definitions.
- **Filament Resources**:
  - **Admin Panel**: Cross-tenant device inventory and global telemetry log viewer.
  - **Portal Panel**: Tenant-scoped device management for organizations.
- **Infrastructure**: Configured PostgreSQL migration to enable TimescaleDB extension and create hypertables for telemetry logs.
- **Data Generation**: Added `DeviceTelemetrySeeder` to generate realistic historical energy meter data (7 days of 15min intervals).

## ✅ Checklist
- [x] All commits follow `US-<issue-number>: <description> #<issue-number>` format
- [x] Tests added/updated and passing (`php artisan test --compact`)
- [x] Code formatted with Pint (`vendor/bin/pint --dirty --format agent`)
- [x] Static analysis passes (`vendor/bin/phpstan analyse`)
- [x] Database migrations tested (up and down)
- [x] Filament resources manually tested in browser
- [x] Documentation updated

## 🧪 Testing Instructions
1. Run `php artisan migrate:fresh --seed` to initialize the database with TimescaleDB support and generate telemetry data.
2. Visit the Admin panel at `/admin` and navigate to **IoT Management > Devices** or **Telemetry Logs**.
3. Visit the Portal panel at `/portal` to manage devices scoped to your organization.
4. Run `php artisan test --filter DeviceTelemetryLogTest` to verify the ingestion logic.

## 📸 Screenshots (if UI changes)
UI changes include new Device and Telemetry Log resources in both Admin and Portal panels.

## 🔗 Related Issues/PRs
- Refers to US-5 (Issue #13) and US-6 (Issue #17)

---
**⚠️ Remember**: This PR should be based on `main` and will be merged back into `main`.